### PR TITLE
Fixed FF not supporting custom sample rate when native sample rate is different

### DIFF
--- a/public/onnx/app-asr-firefox-fix.js
+++ b/public/onnx/app-asr-firefox-fix.js
@@ -1,0 +1,60 @@
+// Firefox-compatible audio context initialization
+function createCompatibleAudioContext() {
+  const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+  
+  if (isFirefox) {
+    // For Firefox, create AudioContext without specifying sample rate
+    // This will use the default sample rate (usually 48000 Hz)
+    // We'll handle resampling manually in the audio processing
+    return new AudioContext();
+  } else {
+    // For Chrome and other browsers, use the optimized 16000 Hz sample rate
+    try {
+      return new AudioContext({ sampleRate: 16000 });
+    } catch (e) {
+      // Fallback if 16000 Hz is not supported
+      console.warn('16000 Hz sample rate not supported, using default');
+      return new AudioContext();
+    }
+  }
+}
+
+// Enhanced downsampling function that handles any source sample rate
+function downsampleToTarget(buffer, sourceSampleRate, targetSampleRate = 16000) {
+  if (sourceSampleRate === targetSampleRate) {
+    return buffer;
+  }
+  
+  const sampleRateRatio = sourceSampleRate / targetSampleRate;
+  const newLength = Math.round(buffer.length / sampleRateRatio);
+  const result = new Float32Array(newLength);
+  
+  // Use linear interpolation for better quality resampling
+  for (let i = 0; i < newLength; i++) {
+    const position = i * sampleRateRatio;
+    const index = Math.floor(position);
+    const fraction = position - index;
+    
+    if (index + 1 < buffer.length) {
+      // Linear interpolation between samples
+      result[i] = buffer[index] * (1 - fraction) + buffer[index + 1] * fraction;
+    } else {
+      result[i] = buffer[index];
+    }
+  }
+  
+  return result;
+}
+
+// Replace the existing AudioContext creation (line 676) with:
+// audioCtx = createCompatibleAudioContext();
+
+// In the onaudioprocess handler, always downsample to 16000 Hz:
+// let samples = new Float32Array(e.inputBuffer.getChannelData(0));
+// samples = downsampleToTarget(samples, audioCtx.sampleRate, 16000);
+
+// Export for use in main file
+if (typeof window !== 'undefined') {
+  window.createCompatibleAudioContext = createCompatibleAudioContext;
+  window.downsampleToTarget = downsampleToTarget;
+}

--- a/public/onnx/app-asr.js
+++ b/public/onnx/app-asr.js
@@ -673,7 +673,22 @@ if (navigator.mediaDevices.getUserMedia) {
 
   let onSuccess = function (stream) {
     if (!audioCtx) {
-      audioCtx = new AudioContext({ sampleRate: 16000 });
+      // Firefox compatibility: detect browser and handle sample rate accordingly
+      const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+      
+      if (isFirefox) {
+        // For Firefox, don't specify sample rate to avoid connection errors
+        audioCtx = new AudioContext();
+        console.log('Firefox detected: using default sample rate', audioCtx.sampleRate);
+      } else {
+        // For Chrome and other browsers, try to use 16000 Hz for efficiency
+        try {
+          audioCtx = new AudioContext({ sampleRate: 16000 });
+        } catch (e) {
+          console.warn('16000 Hz not supported, using default sample rate');
+          audioCtx = new AudioContext();
+        }
+      }
     }
     console.log(audioCtx);
     recordSampleRate = audioCtx.sampleRate;
@@ -702,6 +717,7 @@ if (navigator.mediaDevices.getUserMedia) {
 
     recorder.onaudioprocess = function (e) {
       let samples = new Float32Array(e.inputBuffer.getChannelData(0));
+      // Always downsample from actual sample rate to 16000 Hz for the ASR model
       samples = downsampleBuffer(samples, expectedSampleRate);
 
       if (recognizer_stream == null) {
@@ -1091,15 +1107,21 @@ function toWav(samples) {
 
 // this function is copied from
 // https://github.com/awslabs/aws-lex-browser-audio-capture/blob/master/lib/worker.js#L46
+// Enhanced to always handle downsampling from any rate to target rate
 function downsampleBuffer(buffer, exportSampleRate) {
-  if (exportSampleRate === recordSampleRate) {
+  // Use the actual AudioContext sample rate, not the expected one
+  const sourceSampleRate = audioCtx ? audioCtx.sampleRate : recordSampleRate;
+  
+  if (exportSampleRate === sourceSampleRate) {
     return buffer;
   }
-  var sampleRateRatio = recordSampleRate / exportSampleRate;
+  
+  var sampleRateRatio = sourceSampleRate / exportSampleRate;
   var newLength = Math.round(buffer.length / sampleRateRatio);
   var result = new Float32Array(newLength);
   var offsetResult = 0;
   var offsetBuffer = 0;
+  
   while (offsetResult < result.length) {
     var nextOffsetBuffer = Math.round((offsetResult + 1) * sampleRateRatio);
     var accum = 0,


### PR DESCRIPTION
The problem was that Firefox doesn't support connecting a MediaStreamSource to an AudioContext with a custom sample rate (like 16000 Hz) when the microphone's
  native sample rate is different.

  Changes Made:

  1. Browser Detection: Added Firefox detection to handle AudioContext creation differently for Firefox vs Chrome
  2. Flexible AudioContext Creation:
    - Firefox: Uses default sample rate (typically 48000 Hz) to avoid connection errors
    - Chrome/others: Attempts to use optimized 16000 Hz, with fallback to default
  3. Enhanced Downsampling: Modified the downsampleBuffer function to always use the actual AudioContext sample rate for proper resampling
